### PR TITLE
use safe-buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var varint = require('varint')
+var Buffer = require('safe-buffer').Buffer
 
 exports.encodingLength = encodingLength
 exports.encode = encode
@@ -40,7 +41,7 @@ function encodingLength (bytes) {
 function encode (bytes, buf, offset) {
   var state = new CompressionState(bytes.length)
   var bufLength = rle(bytes, state)
-  if (!buf) buf = Buffer(bufLength)
+  if (!buf) buf = Buffer.alloc(bufLength)
   if (!offset) offset = 0
 
   varint.encode(state.deltas.length / 2, buf, offset)
@@ -94,7 +95,7 @@ function decode (buf, offset) {
   resultLength += 8 * (buf.length - offset)
   if (resultLength & 7) resultLength = resultLength - (resultLength & 7) + 8
 
-  var result = Buffer(resultLength / 8)
+  var result = Buffer.alloc(resultLength / 8)
   var bitfieldOffset = offset * 8
   var bitfieldEnd = buf.length * 8
   var acc = 0
@@ -139,7 +140,7 @@ function set (bitfield, index, val) {
 }
 
 function CompressionState (length) { // using a prototype to make v8 happy
-  this.bitfield = length ? Buffer(length) : null
+  this.bitfield = length ? Buffer.alloc(length) : null
   this.offset = 0
   this.deltas = []
   this.deltasAcc = 0

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A run-length-encoder that compresses bitfields.",
   "main": "index.js",
   "dependencies": {
+    "safe-buffer": "^5.0.1",
     "varint": "^4.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var tape = require('tape')
 var bitfield = require('bitfield')
 var rle = require('./')
+var Buffer = require('safe-buffer').Buffer
 
 tape('encodes and decodes', function (t) {
   var bits = bitfield(1024)
@@ -79,25 +80,25 @@ tape('encodes and decodes with random bits set (not power of two)', function (t)
 })
 
 tape('encodes empty bitfield', function (t) {
-  var deflated = rle.encode(Buffer(0))
+  var deflated = rle.encode(Buffer.alloc(0))
   var inflated = rle.decode(deflated)
-  t.same(inflated, Buffer(0), 'still empty')
+  t.same(inflated, Buffer.alloc(0), 'still empty')
   t.end()
 })
 
 tape('throws on bad input', function (t) {
   t.throws(function () {
-    rle.decode(Buffer([100]))
+    rle.decode(new Buffer([100]))
   }, 'invalid delta count')
   t.throws(function () {
-    rle.decode(Buffer([10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0]))
+    rle.decode(new Buffer([10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0]))
   }, 'missing delta')
   t.end()
 })
 
 tape('not power of two', function (t) {
-  var deflated = rle.encode(Buffer([255, 255, 255, 240]))
+  var deflated = rle.encode(new Buffer([255, 255, 255, 240]))
   var inflated = rle.decode(deflated)
-  t.same(inflated, Buffer([255, 255, 255, 240]), 'output equal to input')
+  t.same(inflated, new Buffer([255, 255, 255, 240]), 'output equal to input')
   t.end()
 })


### PR DESCRIPTION
got the warnings on node 7 that `Buffer()` without `new` will be deprecated, and went the extra mile by upgrading to the safe-buffer module.